### PR TITLE
Fixed start script (start.sh)

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -60,7 +60,7 @@ package_check () {
 }
 
 install_all_packages () {
-    echo "Checking and installing Required packages...."
+    echo -e "[+] Checking and installing Required packages... \n"
     package_check 'python3'
     package_check 'ffmpeg'
     if [ "$on_termux" == "True" ]; then
@@ -69,13 +69,13 @@ install_all_packages () {
 }
 
 activate_venv_and_install_pip_packages () {
-    echo -e "Activating python virtual environment... \n"
+    echo -e "[+] Activating python virtual environment... \n"
     python3 -m venv $ALTRUIX_VENV || sudo python3 -m venv $ALTRUIX_VENV
     source $ALTRUIX_VENV/bin/activate
     if [ "$on_termux" == "True" ]; then
         pip install wheel && pkg install libjpeg-turbo && LDFLAGS="-L/system/lib/" CFLAGS="-I/data/data/com.termux/files/usr/include/" pip install Pillow
     fi
-    echo -e "Installing python dependencies using pip... \n"
+    echo -e "[+] Installing python dependencies using pip... \n"
     pip3 install --upgrade pip || sudo pip3 install --upgrade pip
     pip3 install -U -r requirements.txt || sudo pip3 install -U -r requirements.txt
 }
@@ -94,7 +94,7 @@ main () {
     if [ -f ".env" ]; then
         run_altruix
     else
-        echo -e "ERROR: .env file not found! After creating .env file start the userbot with, \npython3 -m Main"
+        echo -e "ERROR: .env file not found! After creating .env file start the userbot with, \n python3 -m Main"
         exit 1
     fi
 }

--- a/start.sh
+++ b/start.sh
@@ -10,6 +10,7 @@ else
     on_termux=False  
 fi
 
+
 install_package () {
     if [ "$on_termux" == "False" ]; then
         # Apt
@@ -37,7 +38,7 @@ install_package () {
             echo " >> Using: [zypper] to install $1"
             zypper install "$1" || sudo zypper install "$1"
         else
-            echo "Unable to install $1. No compatible package manager found!"
+            echo "ERROR: Unable to install $1. No compatible package manager found!"
             exit 1
         fi
     else
@@ -52,10 +53,9 @@ package_check () {
     else
         PACK=$(command -v "$1" &> /dev/null)
     fi
-    if ! $PACK;
-    then
-        echo "Package $1 not found"
-    install_package "$1"   
+    if ! $PACK; then
+        echo "INFO: Package $1 not found"
+        install_package "$1"   
     fi
 }
 

--- a/start.sh
+++ b/start.sh
@@ -1,3 +1,5 @@
+#! /usr/bin/bash
+
 declare -A pm;
 pm[/etc/redhat-release]=yum
 pm[/etc/arch-release]=pacman
@@ -18,8 +20,8 @@ install_package () {
             do
                 if [[ -f $f ]];then
                     echo "Using : [${pm[$f]}] to install packages"
-                    sudo ${pm[$f]} install "$1" -y || ${pm[$f]} install "$1" -y
-                    fi
+                    ${pm[$f]} install "$1" -y || sudo ${pm[$f]} install "$1" -y
+                fi
             done    }
     else
         echo "Using : [pkg] to install packages"
@@ -46,14 +48,14 @@ install_all_packages () {
 }
 
 activate_venv_and_install_pip_packages () {
-    sudo python3 -m venv venv || python3 -m venv venv
+    python3 -m venv venv || sudo python3 -m venv venv
     source venv/bin/activate
     if [ "$on_termux" == "True" ]; then
         pip install wheel && pkg install libjpeg-turbo && LDFLAGS="-L/system/lib/" CFLAGS="-I/data/data/com.termux/files/usr/include/" pip install Pillow
     fi
-    sudo pip3 install --upgrade pip || pip3 install --upgrade pip
-    sudo pip3 install -r requirements.txt || pip3 install -r requirements.txt
-    sudo python3 -m Main || python3 -m Main
+    pip3 install --upgrade pip || sudo pip3 install --upgrade pip
+    pip3 install -r requirements.txt || sudo pip3 install -r requirements.txt
+    python3 -m Main || sudo python3 -m Main
 }
 
 run () {

--- a/start.sh
+++ b/start.sh
@@ -69,19 +69,33 @@ install_all_packages () {
 }
 
 activate_venv_and_install_pip_packages () {
+    echo -e "Activating python virtual environment... \n"
     python3 -m venv $ALTRUIX_VENV || sudo python3 -m venv $ALTRUIX_VENV
     source $ALTRUIX_VENV/bin/activate
     if [ "$on_termux" == "True" ]; then
         pip install wheel && pkg install libjpeg-turbo && LDFLAGS="-L/system/lib/" CFLAGS="-I/data/data/com.termux/files/usr/include/" pip install Pillow
     fi
+    echo -e "Installing python dependencies using pip... \n"
     pip3 install --upgrade pip || sudo pip3 install --upgrade pip
     pip3 install -U -r requirements.txt || sudo pip3 install -U -r requirements.txt
+}
+
+run_altruix() {
     python3 -m Main || sudo python3 -m Main
 }
 
-run () {
+
+main () {
+    # Install packages
     install_all_packages
+    # Activate python venv and instlall pip packages
     activate_venv_and_install_pip_packages
+    # Check if config file exists
+    if [ -f ".env" ]; then
+        run_altruix
+    else
+        echo -e "ERROR: .env file not found! After creating .env file start the userbot with, \npython3 -m Main"
+    fi
 }
 
-run
+main

--- a/start.sh
+++ b/start.sh
@@ -75,7 +75,7 @@ activate_venv_and_install_pip_packages () {
         pip install wheel && pkg install libjpeg-turbo && LDFLAGS="-L/system/lib/" CFLAGS="-I/data/data/com.termux/files/usr/include/" pip install Pillow
     fi
     pip3 install --upgrade pip || sudo pip3 install --upgrade pip
-    pip3 install -r -U requirements.txt || sudo pip3 install -r requirements.txt
+    pip3 install -U -r requirements.txt || sudo pip3 install -U -r requirements.txt
     python3 -m Main || sudo python3 -m Main
 }
 

--- a/start.sh
+++ b/start.sh
@@ -95,6 +95,7 @@ main () {
         run_altruix
     else
         echo -e "ERROR: .env file not found! After creating .env file start the userbot with, \npython3 -m Main"
+        exit 1
     fi
 }
 

--- a/start.sh
+++ b/start.sh
@@ -11,30 +11,30 @@ else
 fi
 
 
-install_package () {
+install_package() {
     if [ "$on_termux" == "False" ]; then
         # Apt
-        if package_check "apt" -v; then
+        if package_check "apt"; then
             echo " >> Using: [apt] to install $1"
             apt install "$1" || sudo apt install "$1"
         # Apt-get
-        elif package_check "apt-get" -v; then
+        elif package_check "apt-get"; then
             echo " >> Using: [apt-get] to install $1"
             apt-get install "$1" || sudo apt-get install "$1"
         # Pacman
-        elif package_check "pacman" -v; then
+        elif package_check "pacman"; then
             echo " >> Using: [pacman] to install $1"
             pacman -S "$1" || sudo pacman -S "$1"
         # Yum
-        elif package_check "yum" -v; then
+        elif package_check "yum"; then
             echo " >> Using: [yum] to install $1"
             yum install "$1" || sudo yum install "$1"
         # Apk
-        elif package_check "apk" -v; then
+        elif package_check "apk"; then
             echo " >> Using: [apk] to install $1"
             apk add "$1" || sudo apk add "$1"
         # Zypper
-        elif package_check "zypper" -v; then
+        elif package_check "zypper"; then
             echo " >> Using: [zypper] to install $1"
             zypper install "$1" || sudo zypper install "$1"
         else
@@ -47,19 +47,15 @@ install_package () {
     fi
 }
 
-package_check () {
-    if [ "$2" == -v ]; then
-        PACK=$(command -v "$1")
-    else
-        PACK=$(command -v "$1" &> /dev/null)
-    fi
+package_check() {
+    PACK=$(command -v "$1" &> /dev/null)
     if ! $PACK; then
         echo "INFO: Package $1 not found"
         install_package "$1"   
     fi
 }
 
-install_all_packages () {
+install_all_packages() {
     echo -e "[+] Checking and installing Required packages... \n"
     package_check 'python3'
     package_check 'ffmpeg'
@@ -68,7 +64,7 @@ install_all_packages () {
     fi
 }
 
-activate_venv_and_install_pip_packages () {
+activate_venv_and_install_pip_packages() {
     echo -e "[+] Activating python virtual environment... \n"
     python3 -m venv $ALTRUIX_VENV || sudo python3 -m venv $ALTRUIX_VENV
     source $ALTRUIX_VENV/bin/activate
@@ -85,7 +81,7 @@ run_altruix() {
 }
 
 
-main () {
+main() {
     # Install packages
     install_all_packages
     # Activate python venv and instlall pip packages

--- a/start.sh
+++ b/start.sh
@@ -12,30 +12,46 @@ fi
 
 install_package () {
     if [ "$on_termux" == "False" ]; then
-        if package_check "apt"; then
-            apt install $1 || sudo apt install $1
-        elif package_check "apt-get"; then
-            apt-get install $1 || sudo apt-get install $1
-        elif package_check "pacman"; then
-            pacman -S $1 || sudo pacman -S $1
-        elif package_check "yum"; then
-            yum install $1 || sudo yum install $1
-        elif package_check "apk"; then
-            apk add $1 || sudo apk add $1
-        elif package_check "zypper"; then
-            zypper install $1 || sudo zypper install $1
+        # Apt
+        if package_check "apt" -v; then
+            echo " >> Using: [apt] to install $1"
+            apt install "$1" || sudo apt install "$1"
+        # Apt-get
+        elif package_check "apt-get" -v; then
+            echo " >> Using: [apt-get] to install $1"
+            apt-get install "$1" || sudo apt-get install "$1"
+        # Pacman
+        elif package_check "pacman" -v; then
+            echo " >> Using: [pacman] to install $1"
+            pacman -S "$1" || sudo pacman -S "$1"
+        # Yum
+        elif package_check "yum" -v; then
+            echo " >> Using: [yum] to install $1"
+            yum install "$1" || sudo yum install "$1"
+        # Apk
+        elif package_check "apk" -v; then
+            echo " >> Using: [apk] to install $1"
+            apk add "$1" || sudo apk add "$1"
+        # Zypper
+        elif package_check "zypper" -v; then
+            echo " >> Using: [zypper] to install $1"
+            zypper install "$1" || sudo zypper install "$1"
         else
             echo "Unable to install $1. No compatible package manager found!"
             exit 1
         fi
     else
-        echo "Using: [pkg] to install packages"
+        echo "Using: [pkg] to install $1"
         pkg install "$1" -y 
-fi
+    fi
 }
 
 package_check () {
-    PACK=$(command -v "$1" &> /dev/null)
+    if [ "$2" == -v ]; then
+        PACK=$(command -v "$1")
+    else
+        PACK=$(command -v "$1" &> /dev/null)
+    fi
     if ! $PACK;
     then
         echo "Package $1 not found"

--- a/start.sh
+++ b/start.sh
@@ -8,6 +8,10 @@ pm[/etc/SuSE-release]=zypp
 pm[/etc/debian_version]=apt-get
 pm[/etc/alpine-release]=apk
 
+# Vir
+ALTRUIX_VENV="Altruix"
+
+
 if [ $(echo $PREFIX | grep -o 'com.termux') ];then
     on_termux=True
 else
@@ -42,19 +46,19 @@ install_all_packages () {
     echo "Checking and installing Required packages...."
     package_check 'python3'
     package_check 'ffmpeg'
-    if [ "$on_termux" == "False" ]; then
+    if [ "$on_termux" == "True" ]; then
         package_check 'python3-venv'
     fi
 }
 
 activate_venv_and_install_pip_packages () {
-    python3 -m venv venv || sudo python3 -m venv venv
-    source venv/bin/activate
+    python3 -m venv $ALTRUIX_VENV || sudo python3 -m venv $ALTRUIX_VENV
+    source $ALTRUIX_VENV/bin/activate
     if [ "$on_termux" == "True" ]; then
         pip install wheel && pkg install libjpeg-turbo && LDFLAGS="-L/system/lib/" CFLAGS="-I/data/data/com.termux/files/usr/include/" pip install Pillow
     fi
     pip3 install --upgrade pip || sudo pip3 install --upgrade pip
-    pip3 install -r requirements.txt || sudo pip3 install -r requirements.txt
+    pip3 install -r -U requirements.txt || sudo pip3 install -r requirements.txt
     python3 -m Main || sudo python3 -m Main
 }
 

--- a/start.sh
+++ b/start.sh
@@ -28,11 +28,12 @@ fi
 }
 
 package_check () {
-if [ $(dpkg-query -W -f='${Status}' $1 2>/dev/null | grep -c "ok installed") -eq 0 ];
-then
-  echo "Package $1 not found. Installing package $1"
-  install_package "$1"   
-fi
+    PACK=$(command -v "$1" &> /dev/null)
+    if ! $PACK;
+    then
+        echo "Package $1 not found. Installing package $1"
+    install_package "$1"   
+    fi
 }
 
 install_all_packages () {


### PR DESCRIPTION
Changes:
- Use if else statements to check the package manager (not every package manager uses `install <package_name>` syntax)
- Use `command` instead of `dpkg-query` to check if a package is installed
- Changed python virtual environment name from `venv` to `Altruix`
- Run commands on super user mode only if the current user doesn't have permission(s)
- Look for `.env` file before starting the userbot (if not exists throws an error message and exit the script with status 1)